### PR TITLE
Added support for environment variables in the path string.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
+shellexpand = "3.1.0"
 quote = "1.0"
 syn = "2.0"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ const FILE: &'static str = include_absolute_path!("src/main.rs");
 
 This will set `FILE` to the absolute path of the `src/main.rs` file relative to the file where the macro is called.
 
+## Environment Variable Support
+
+The `include_absolute_path!` macro also supports environment variables. You can use environment variables in the path, and they will be expanded before the path is resolved.
+
+```rust
+const HOME_DIR: &'static str = include_absolute_path!("$HOME");
+```
+
+This will set `HOME_DIR` to the absolute path of the home directory.
+
 ## How It Works
 
 The `include_absolute_path!` macro works by parsing the input path and checking if it's absolute. If it is, it returns the path as is. If it's not, it concatenates the path with the directory of the file where the macro is called to get the absolute path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,12 @@ pub fn include_absolute_path(input: TokenStream) -> TokenStream {
     let path = parse_macro_input!(input as LitStr).value();
     let caller_file = proc_macro::Span::call_site().source_file().path();
 
-    // Convert the path to a Path
-    let path = std::path::Path::new(&path);
+    // Expand environment variables in the path
+    let expanded_path = shellexpand::env(&path)
+        .unwrap_or_else(|_| panic!("Failed to expand environment variable in path: {}", path));
+
+    // Convert the expanded path to a Path
+    let path = std::path::Path::new(expanded_path.as_ref());
 
     // Check if the path is absolute
     let raw_path = if path.is_absolute() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -12,3 +12,20 @@ fn test_relative_include_absolute_path() {
     let contents = std::fs::read_to_string(PATH).unwrap();
     assert_eq!(contents, "Hello World!");
 }
+
+#[test]
+fn test_containing_env_variable_include_absolute_path() {
+    const ACTUAL: &str = include_absolute_path!("$HOME");
+    let expected = std::env::var("HOME").unwrap();
+    assert_eq!(ACTUAL, expected);
+}
+
+#[test]
+fn test_containing_env_variable_with_subpath_include_absolute_path() {
+    const ACTUAL: &str = include_absolute_path!("$HOME/../");
+    let expected_path =
+        std::path::absolute(format!("{}/../", std::env::var("HOME").unwrap())).unwrap();
+    let expected_canocalized = expected_path.canonicalize().unwrap();
+    let expected = expected_canocalized.to_str().unwrap();
+    assert_eq!(ACTUAL, expected);
+}


### PR DESCRIPTION
Having environment variable, support for shell expansion is incredibly handy. 

` include_absolute_path!("$HOME")` 